### PR TITLE
Email plugin

### DIFF
--- a/convert/jenkinsjson/convertTestFiles/emailExt/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/emailExt/Jenkinsfile
@@ -1,0 +1,16 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('fail') {
+            steps {
+                sh 'exit 0'
+            }
+        }
+    }
+    post {
+        always {
+            emailext subject: 'Email ${BUILD_STATUS}', body: 'Email ${BUILD_NUMBER}', to: 'first@example.com second@example.com'
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/emailExt/emailExt.yaml
+++ b/convert/jenkinsjson/convertTestFiles/emailExt/emailExt.yaml
@@ -1,0 +1,15 @@
+- step:
+    identifier: emailext2b1b55
+    name: emailext
+    spec:
+      image: plugins/email
+      settings:
+        body: Email <+pipeline.sequenceId>
+        from: ""
+        host: <+input>
+        replyTo: ""
+        subject: Email <+pipeline.status>
+        to: first@example.com second@example.com
+      timeout: ""
+    type: Plugin
+    timeout: ""

--- a/convert/jenkinsjson/convertTestFiles/emailExt/emailExtSnippet.json
+++ b/convert/jenkinsjson/convertTestFiles/emailExt/emailExtSnippet.json
@@ -1,0 +1,25 @@
+{
+    "spanId": "2b1b55f61141729a",
+    "traceId": "56848b8bebfec347bea6a32469b7306a",
+    "parent": "Email",
+    "all-info": "span(name: emailext, spanId: 2b1b55f61141729a, parentSpanId: ebcdc317572db2e1, traceId: 56848b8bebfec347bea6a32469b7306a, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"body\" : \"Email ${BUILD_NUMBER}\",\n  \"subject\" : \"Email ${BUILD_STATUS}\",\n  \"to\" : \"first@example.com second@example.com\"\n};harness-others:-subject-field hudson.plugins.emailext.EmailExtStep subject-hudson.plugins.emailext.EmailExtStep.subject-class java.lang.String-body-field hudson.plugins.emailext.EmailExtStep body-hudson.plugins.emailext.EmailExtStep.body-class java.lang.String;jenkins.pipeline.step.id:12;jenkins.pipeline.step.name:Extended Email;jenkins.pipeline.step.plugin.name:email-ext;jenkins.pipeline.step.plugin.version:1814.v404722f34263;jenkins.pipeline.step.type:emailext;)",
+    "name": "Email #26",
+    "attributesMap": {
+      "harness-others": "-subject-field hudson.plugins.emailext.EmailExtStep subject-hudson.plugins.emailext.EmailExtStep.subject-class java.lang.String-body-field hudson.plugins.emailext.EmailExtStep body-hudson.plugins.emailext.EmailExtStep.body-class java.lang.String",
+      "jenkins.pipeline.step.name": "Extended Email",
+      "ci.pipeline.run.user": "SYSTEM",
+      "jenkins.pipeline.step.id": "12",
+      "jenkins.pipeline.step.type": "emailext",
+      "harness-attribute": "{\n  \"body\" : \"Email ${BUILD_NUMBER}\",\n  \"subject\" : \"Email ${BUILD_STATUS}\",\n  \"to\" : \"first@example.com second@example.com\"\n}",
+      "jenkins.pipeline.step.plugin.name": "email-ext",
+      "jenkins.pipeline.step.plugin.version": "1814.v404722f34263"
+    },
+    "type": "Run Phase Span",
+    "parentSpanId": "ebcdc317572db2e1",
+    "parameterMap": {
+      "subject": "Email ${BUILD_STATUS}",
+      "to": "first@example.com second@example.com",
+      "body": "Email ${BUILD_NUMBER}"
+    },
+    "spanName": "emailext"
+}

--- a/convert/jenkinsjson/covert.go
+++ b/convert/jenkinsjson/covert.go
@@ -356,6 +356,9 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 		for _, step := range archiveSteps {
 			*stepWithIDList = append(*stepWithIDList, StepWithID{Step: step, ID: id})
 		}
+	case "emailext":
+		// Id coming for this case
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertEmailext(currentNode, variables), ID: id})
 	case "junit":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertJunit(currentNode, variables), ID: id})
 	case "git":

--- a/convert/jenkinsjson/json/emailExt.go
+++ b/convert/jenkinsjson/json/emailExt.go
@@ -1,0 +1,51 @@
+package json
+
+import (
+	"strings"
+
+	harness "github.com/drone/spec/dist/go"
+)
+
+func ConvertEmailext(node Node, variables map[string]string) *harness.Step {
+	tokenReplacements := map[string]string{
+		"${BUILD_NUMBER}": "<+pipeline.sequenceId>",
+		"${BUILD_STATUS}": "<+pipeline.status>",
+		"${PROJECT_NAME}": "<+project.name>",
+		"${BUILD_URL}":    "<+pipeline.executionUrl>",
+		"${BUILD_USER}":   "<+pipeline.triggeredBy.email>",
+	}
+
+	replaceTokens := func(input string) string {
+		for token, replacement := range tokenReplacements {
+			input = strings.ReplaceAll(input, token, replacement)
+		}
+		return input
+	}
+	getStringValue := func(key string) string {
+		if value, ok := node.ParameterMap[key].(string); ok {
+			return replaceTokens(value)
+		}
+		return ""
+	}
+
+	step := &harness.Step{
+		Name: node.SpanName,
+		Id:   SanitizeForId(node.SpanName, node.SpanId),
+		Type: "plugin",
+		Spec: &harness.StepPlugin{
+			Image: "plugins/email",
+			With: map[string]interface{}{
+				"subject": getStringValue("subject"),
+				"body":    getStringValue("body"),
+				"to":      node.ParameterMap["to"],
+				"from":    node.ParameterMap["from"],
+				"replyTo": node.ParameterMap["replyTo"],
+				"host":    "<+input>",
+			},
+		},
+	}
+	if len(variables) > 0 {
+		step.Spec.(*harness.StepExec).Envs = variables
+	}
+	return step
+}

--- a/convert/jenkinsjson/json/emailExt_test.go
+++ b/convert/jenkinsjson/json/emailExt_test.go
@@ -1,0 +1,115 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	harness "github.com/drone/spec/dist/go"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertEmailext(t *testing.T) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	filePath := filepath.Join(workingDir, "../convertTestFiles/emailext/emailextSnippet.json")
+	jsonData, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read JSON file: %v", err)
+	}
+
+	var rawNode map[string]interface{}
+	if err := json.Unmarshal(jsonData, &rawNode); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	node1 := Node{}
+	if err := mapToNodes(rawNode, &node1); err != nil {
+		t.Fatalf("failed to convert raw node to Node: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		json Node
+		vars map[string]string
+		want *harness.Step
+	}{
+		{
+			name: "Basic Conversion",
+			json: node1,
+			want: &harness.Step{
+				Name: "emailext",
+				Id:   "emailext2b1b55",
+				Type: "plugin",
+				Spec: &harness.StepPlugin{
+					Image: "plugins/email",
+					With: map[string]interface{}{
+						"subject": "Email <+pipeline.status>",
+						"body":    "Email <+pipeline.sequenceId>",
+						"to":      "first@example.com second@example.com",
+						"from":    "",
+						"replyTo": "",
+						"host":    "<+input>",
+					},
+				},
+			},
+		},
+		{
+			name: "Missing Fields",
+			json: Node{
+				SpanName: "emailext",
+				SpanId:   "2b1b55",
+			},
+			want: &harness.Step{
+				Name: "emailext",
+				Id:   "emailext2b1b55",
+				Type: "plugin",
+				Spec: &harness.StepPlugin{
+					Image: "plugins/email",
+					With: map[string]interface{}{
+						"subject": "",
+						"body":    "",
+						"to":      "",
+						"from":    "",
+						"replyTo": "",
+						"host":    "<+input>",
+					},
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ConvertEmailext(test.json, test.vars)
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("Unexpected conversion results for test %v", i)
+				t.Log(diff)
+			}
+		})
+	}
+}
+
+func mapToNodes(raw map[string]interface{}, node *Node) error {
+	node.AttributesMap = make(map[string]string)
+	for k, v := range raw["attributesMap"].(map[string]interface{}) {
+		node.AttributesMap[k] = fmt.Sprintf("%v", v)
+	}
+
+	node.Name = raw["name"].(string)
+	node.Parent = raw["parent"].(string)
+	node.ParentSpanId = raw["parentSpanId"].(string)
+	node.SpanId = raw["spanId"].(string)
+	node.SpanName = raw["spanName"].(string)
+	node.TraceId = raw["traceId"].(string)
+	node.Type = raw["type"].(string)
+	node.ParameterMap = raw["parameterMap"].(map[string]interface{})
+
+	return nil
+}


### PR DESCRIPTION
Changes wrt to The Email Plugin.
Converted these token to the Equivalent harness Expression.
 `"${BUILD_NUMBER}": "<+pipeline.sequenceId>",
		"${BUILD_STATUS}": "<+pipeline.status>",
		"${PROJECT_NAME}": "<+project.name>",
		"${BUILD_URL}":    "<+pipeline.executionUrl>",
		"${BUILD_USER}":   "<+pipeline.triggeredBy.email>",`